### PR TITLE
Remove zend-mime dependency, add zend-http dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": ">=5.3.3",
         "zendframework/zend-mail": ">=2.0,<=2.3",
-        "zendframework/zend-mime": ">=2.0,<=2.3"
+        "zendframework/zend-http": ">=2.0,<=2.3"
     },
     "require-dev": {
         "aws/aws-sdk-php-zf2": ">=1.0.1"


### PR DESCRIPTION
The zend-mime is required by zend-mail already. For all except SES
is the zend-http required.
