### PR TITLE
When sending in POST, parameters should be in POST also

### DIFF
--- a/src/SlmMail/Service/SendGridService.php
+++ b/src/SlmMail/Service/SendGridService.php
@@ -138,6 +138,7 @@ class SendGridService extends AbstractMailService
 
         $response = $client->setMethod(HttpRequest::METHOD_POST)
                            ->setEncType(HttpClient::ENC_FORMDATA)
+                           ->setParameterPost($parameters)
                            ->send();
 
         return $this->parseResponse($response);


### PR DESCRIPTION
sending is using POST method, but in prepareHttpClient(), there is a set to GET parameters only.
Added POST parameters
