### PR TITLE
Only send parameters via POST, not both

### DIFF
--- a/src/SlmMail/Service/SendGridService.php
+++ b/src/SlmMail/Service/SendGridService.php
@@ -126,7 +126,7 @@ class SendGridService extends AbstractMailService
             $parameters['replyto'] = $replyTo->rewind()->getEmail();
         }
 
-        $client = $this->prepareHttpClient('/mail.send.json', $parameters);
+        $client = $this->prepareHttpClient('/mail.send.json');
         // Set Parameters as POST, since prepareHttpClient() put only GET parameters
         $client->setParameterPost($parameters);
         


### PR DESCRIPTION
An addition has been made to send parameters via POST, but they
were set via GET as well. Remove the GET parameter since most people
succeed with POSTing to the SendGrid server. Otherwise, the double
parameters only cost an additional load.
