### PR TITLE
Allow non template Mandrill messages to have variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.1.1
+
+- Allow non-template Mandrill messages to have merge variables
+
 ## 1.1.0
 
 - Add support for Mandrill subaccounts API

--- a/src/SlmMail/Service/MandrillService.php
+++ b/src/SlmMail/Service/MandrillService.php
@@ -771,29 +771,29 @@ class MandrillService extends AbstractMailService
                 if (!isset($parameters['template_content'])) {
                     $parameters['template_content'] = array();
                 }
+            }
 
-                foreach ($message->getGlobalVariables() as $key => $value) {
-                    $parameters['message']['global_merge_vars'][] = array(
+            foreach ($message->getGlobalVariables() as $key => $value) {
+                $parameters['message']['global_merge_vars'][] = array(
+                    'name'    => $key,
+                    'content' => $value
+                );
+            }
+
+            foreach ($message->getVariables() as $recipient => $variables) {
+                $recipientVariables = array();
+
+                foreach ($variables as $key => $value) {
+                    $recipientVariables[] = array(
                         'name'    => $key,
                         'content' => $value
                     );
                 }
 
-                foreach ($message->getVariables() as $recipient => $variables) {
-                    $recipientVariables = array();
-
-                    foreach ($variables as $key => $value) {
-                        $recipientVariables[] = array(
-                            'name'    => $key,
-                            'content' => $value
-                        );
-                    }
-
-                    $parameters['message']['merge_vars'][] = array(
-                        'rcpt' => $recipient,
-                        'vars' => $recipientVariables
-                    );
-                }
+                $parameters['message']['merge_vars'][] = array(
+                    'rcpt' => $recipient,
+                    'vars' => $recipientVariables
+                );
             }
 
             foreach ($message->getOptions() as $key => $value) {

--- a/src/SlmMail/Version.php
+++ b/src/SlmMail/Version.php
@@ -42,5 +42,5 @@ namespace SlmMail;
 
 class Version
 {
-    const VERSION = '1.1.0';
+    const VERSION = '1.1.1';
 }


### PR DESCRIPTION
I realized that merge variables were only set if a template was attached, but you can send your own mail without having a template and still having the feature of merging variables.

I need this, can you quickly merge this and tag 1.1.1 please ? :)
