### PR TITLE
Boom! Make SlmMail compatible with Zend\Mail\Transport

### DIFF
--- a/src/SlmMail/Service/MailServiceInterface.php
+++ b/src/SlmMail/Service/MailServiceInterface.php
@@ -41,7 +41,7 @@
 namespace SlmMail\Service;
 
 use Zend\Mail\Message;
-use Zend\Mail\TransportInterface;
+use Zend\Mail\Transport\TransportInterface;
 
 interface MailServiceInterface extends TransportInterface
 {


### PR DESCRIPTION
This makes it possible to use it with stuff like SxMail and other modules relying on `Zend\Mail\TransportInterface`.

Frankly, I think this interface should be dropped in favor of Zend\Mail\TransportInterface, as they are identical.
