### PR TITLE
Update SendGridService.php

### DIFF
--- a/src/SlmMail/Service/SendGridService.php
+++ b/src/SlmMail/Service/SendGridService.php
@@ -135,7 +135,7 @@ class SendGridService extends AbstractMailService
         $post        = $client->getRequest()->getPost();
         $attachments = $this->extractAttachments($message);
         foreach ($attachments as $attachment) {
-            $post->set('files[' . $attachment->filename . ']', $attachment->getRawContent() . ';type=' . $attachment->type);
+            $post->set('files[' . $attachment->filename . ']', $attachment->getRawContent());
         }
 
         $response = $client->setMethod(HttpRequest::METHOD_POST)


### PR DESCRIPTION
SendGrid should not attach a filetype

This is causing serious issues and serves no purpose. Remove the bug from the library! I use SendGrid and can tell you that it won't work. Most file readers are smart enough to detect a corrupted textual addition to the file, but then preview mode is disabled in Outlook.
