### PR TITLE
Fix: Remove unused imports

### DIFF
--- a/src/SlmMail/Service/ElasticEmailService.php
+++ b/src/SlmMail/Service/ElasticEmailService.php
@@ -41,7 +41,6 @@
 namespace SlmMail\Service;
 
 use SlmMail\Mail\Message\ElasticEmail as ElasticEmailMessage;
-use SlmMail\Service\AbstractMailService;
 use Zend\Http\Request as HttpRequest;
 use Zend\Http\Response as HttpResponse;
 use Zend\Mail\Address;

--- a/src/SlmMail/Service/MailgunService.php
+++ b/src/SlmMail/Service/MailgunService.php
@@ -41,7 +41,6 @@
 namespace SlmMail\Service;
 
 use SlmMail\Mail\Message\Mailgun as MailgunMessage;
-use SlmMail\Service\AbstractMailService;
 use Zend\Http\Client   as HttpClient;
 use Zend\Http\Request  as HttpRequest;
 use Zend\Http\Response as HttpResponse;
@@ -142,7 +141,7 @@ class MailgunService extends AbstractMailService
             if (count($tags) > 0) {
                 $parameters['o:tag'] = $tags;
             }
-            
+
             $variables = $message->getRecipientVariables();
             if (count($variables)) {
                 // It is only possible to add variables for recipients that exist in the To: field
@@ -154,7 +153,7 @@ class MailgunService extends AbstractMailService
                         ));
                     }
                 }
-    
+
                 $parameters['recipient-variables'] = json_encode($variables);
             }
         }

--- a/src/SlmMail/Service/MandrillService.php
+++ b/src/SlmMail/Service/MandrillService.php
@@ -43,7 +43,6 @@ namespace SlmMail\Service;
 use DateTime;
 use DateTimeZone;
 use SlmMail\Mail\Message\Mandrill as MandrillMessage;
-use SlmMail\Service\AbstractMailService;
 use Zend\Http\Request  as HttpRequest;
 use Zend\Http\Response as HttpResponse;
 use Zend\Mail\Address;

--- a/src/SlmMail/Service/PostageService.php
+++ b/src/SlmMail/Service/PostageService.php
@@ -41,7 +41,6 @@
 namespace SlmMail\Service;
 
 use SlmMail\Mail\Message\Postage as PostageMessage;
-use SlmMail\Service\AbstractMailService;
 use Zend\Http\Request as HttpRequest;
 use Zend\Http\Response as HttpResponse;
 use Zend\Mail\Address;

--- a/src/SlmMail/Service/PostmarkService.php
+++ b/src/SlmMail/Service/PostmarkService.php
@@ -41,7 +41,6 @@
 namespace SlmMail\Service;
 
 use SlmMail\Mail\Message\Postmark as PostmarkMessage;
-use SlmMail\Service\AbstractMailService;
 use Zend\Http\Request as HttpRequest;
 use Zend\Http\Response as HttpResponse;
 use Zend\Mail\Address;

--- a/src/SlmMail/Service/SendGridService.php
+++ b/src/SlmMail/Service/SendGridService.php
@@ -40,7 +40,6 @@
 
 namespace SlmMail\Service;
 
-use SlmMail\Service\AbstractMailService;
 use Zend\Http\Client   as HttpClient;
 use Zend\Http\Request  as HttpRequest;
 use Zend\Http\Response as HttpResponse;
@@ -129,7 +128,7 @@ class SendGridService extends AbstractMailService
         $client = $this->prepareHttpClient('/mail.send.json');
         // Set Parameters as POST, since prepareHttpClient() put only GET parameters
         $client->setParameterPost($parameters);
-        
+
         // Eventually add files. This cannot be done before prepareHttpClient call because prepareHttpClient
         // reset all parameters (response, request...), therefore we would loose the file upload
         $post        = $client->getRequest()->getPost();

--- a/src/SlmMail/Service/SesService.php
+++ b/src/SlmMail/Service/SesService.php
@@ -42,7 +42,6 @@ namespace SlmMail\Service;
 
 use Aws\Ses\Exception\SesException;
 use Aws\Ses\SesClient;
-use SlmMail\Service\AbstractMailService;
 use Zend\Mail\Address;
 use Zend\Mail\Message;
 


### PR DESCRIPTION
No need to import `SlmMail\Service\AbstractMailService` as importing files are already in the same namespace.
