### PR TITLE
SparkPost: Add support for subaccounts

### DIFF
--- a/docs/SparkPost.md
+++ b/docs/SparkPost.md
@@ -19,42 +19,27 @@ Usage
 
 ### Supported functionalities
 
-SlmMail consumes for SparkPost just the standard `Laminas\Mail\Message` object.
+In addition to the default `Laminas\Mail\Message` class, SlmMail offers the SparkPost-specific `SlmMail\Message\SparkPost` class as input for sending email. The latter supports native templates and attachments for the more advanced use cases.
 
-When the SparkPostService was constructed with a DKIM-config object, the following methods let you register, verify and remove sending domains:
+#### Subaccounts
 
-* registerSendingDomain: Registers a new sending domain using the default DKIM keypair and selector that were configured using the constructor. If the sending domain already exists in SparkPost, the existing sending domain is preserved and the function returns successfully.
-* removeSendingDomain: Remove a sending domain. If the sending domains does not exist on SparkPost the fuction returns successfully.
+SparkPost allows multiple *subaccounts* to be used in addition the main account. SlmMail supports subaccounts on SparkPost through the `'subaccount'` option which can be passed along to any method of the `SparkPostService`. Please note that the numeric subaccount **ID** must be used, not the symbolic name of the subaccount.
+
+#### Sending domains
+
+The following SparkPostService-methods let you register, verify and remove sending domains:
+
+* registerSendingDomain: Registers a new sending domain using the DKIM-keypair and selector that were given in the `'dkim'` option. If the sending domain already exists in SparkPost, the existing sending domain is preserved and the function returns successfully.
+
+* removeSendingDomain: Remove a sending domain. If the sending domains does not exist on SparkPost the function returns successfully.
+
 * verifySendingDomain: Requests verification of the DKIM-record of a previously registered sending domain.
 
 #### Attachments
 
-You can add any attachment to a SparkPost message. Attachments are handled just like you normally send emails with attachments. See the [Zend Framework 2 manual](http://framework.zend.com/manual/2.0/en/modules/zend.mail.message.html) for an extensive explanation of the Message class.
-=======
-SlmMail consumes for SparkPosrt just the standard `Laminas\Mail\Message` object.
+You can add any attachment to a `SparkPost` message using the `addAttachment` method. Please note that the contents of the attachment must be base64-encoded *before* adding the attachment.
 
-#### Attachments
-
-You can add any attachment to a SparkPost message. Attachments are handled just like you normally send emails with attachments. See the [Zend Framework 2 manual](http://framework.zend.com/manual/2.0/en/modules/zend.mail.message.html) for an extensive explanation of the Message class.
->>>>>>> Temporary merge branch 2
-
-```php
-$text = new \Laminas\Mime\Part($textContent);
-$text->type = "text/plain";
-
-$html = new \Laminas\Mime\Part($htmlMarkup);
-$html->type = "text/html";
-
-$pdf = new \Laminas\Mime\Part(fopen($pathToPdf, 'r'));
-$pdf->type     = "application/pdf";
-$pdf->filename = "my-attachment.pdf";
-
-$body = new \Laminas\Mime\Message;
-$body->setParts(array($text, $html, $pdf));
-
-$message = new \Laminas\Mail\Message;
-$message->setBody($body);
-```
+SparkPost limits the total message size to ~20 MB, including base64-encoded attachments. In fact, SparkPost's advice is not to include any attachments to increase the chances of landing in the inbox.
 
 ### Use service locator
 

--- a/src/Service/SparkPostService.php
+++ b/src/Service/SparkPostService.php
@@ -487,13 +487,15 @@ class SparkPostService extends AbstractMailService
         $allHeaders['Authorization'] = $this->apiKey;
         $allHeaders['Content-Type'] = 'application/json';
 
-        return $this->getClient()
+        $client = $this->getClient()
             ->resetParameters()
-            ->setHeaders($allHeaders)
             ->setMethod(HttpRequest::METHOD_POST)
             ->setUri(self::API_ENDPOINT . $uri)
             ->setRawBody($parameters)
         ;
+        $client->setHeaders($allHeaders);
+
+        return $client;
     }
 
     /**

--- a/src/Service/SparkPostService.php
+++ b/src/Service/SparkPostService.php
@@ -84,10 +84,17 @@ class SparkPostService extends AbstractMailService
             );
         }
 
+        $options = $message instanceof SparkPostMessage ? $message->getOptions() : [];
+        $headers = [];
+
+        if(array_key_exists('subaccount', $options) && is_string($options['subaccount'])) {
+            $headers['X-MSYS-SUBACCOUNT'] = $options['subaccount'];
+        }
+
         // Prepare POST-body
         $post = $recipients;
         $post['content'] = $this->prepareContent($message);
-        $post['options'] = $message instanceof SparkPostMessage ? $message->getOptions() : [];
+        $post['options'] = $options;
         $post['metadata'] = $this->prepareMetadata($message);
 
         if($message instanceof SparkPostMessage && $message->getGlobalVariables()) {
@@ -102,7 +109,7 @@ class SparkPostService extends AbstractMailService
             $post['return_path'] = $message->getReturnPath();
         }
 
-        $response = $this->prepareHttpClient('/transmissions', $post)
+        $response = $this->prepareHttpClient('/transmissions', $post, $headers)
             ->send()
         ;
 
@@ -317,6 +324,12 @@ class SparkPostService extends AbstractMailService
 
     public function registerSendingDomain(string $domain, array $options = []): bool
     {
+        $headers = [];
+
+        if(array_key_exists('subaccount', $options) && is_string($options['subaccount'])) {
+            $headers['X-MSYS-SUBACCOUNT'] = $options['subaccount'];
+        }
+
         $post = [
             'domain' => urlencode($domain),
         ];
@@ -326,7 +339,7 @@ class SparkPostService extends AbstractMailService
             $post['dkim'] = $options['dkim'];
         }
 
-        $response = $this->prepareHttpClient('/sending-domains', $post)
+        $response = $this->prepareHttpClient('/sending-domains', $post, $headers)
             ->send()
         ;
 
@@ -348,8 +361,14 @@ class SparkPostService extends AbstractMailService
     /**
      * Add an email address to the suppression lists for transactional email, non-transactional email, or both
      */
-    public function addToSuppressionList(string $emailAddress, string $reason, array $suppressionLists = self::SUPPRESSION_LISTS): void
+    public function addToSuppressionList(string $emailAddress, string $reason, array $suppressionLists = self::SUPPRESSION_LISTS, array $options = []): void
     {
+        $headers = [];
+
+        if(array_key_exists('subaccount', $options) && is_string($options['subaccount'])) {
+            $headers['X-MSYS-SUBACCOUNT'] = $options['subaccount'];
+        }
+
         $put = [
             'recipients' => [],
         ];
@@ -365,7 +384,7 @@ class SparkPostService extends AbstractMailService
         }
 
         if ($put['recipients']) {
-            $response = $this->prepareHttpClient('/suppression-list/', $put)
+            $response = $this->prepareHttpClient('/suppression-list/', $put, $headers)
                 ->setMethod(HttpRequest::METHOD_PUT)
                 ->send();
 
@@ -376,15 +395,21 @@ class SparkPostService extends AbstractMailService
     /**
      * Remove an email address from the suppression lists for transactional email, non-transactional email, or both
      */
-    public function removeFromSuppressionList(string $emailAddress, array $suppressionLists = self::SUPPRESSION_LISTS): void
+    public function removeFromSuppressionList(string $emailAddress, array $suppressionLists = self::SUPPRESSION_LISTS, $options = []): void
     {
+        $headers = [];
+
+        if(array_key_exists('subaccount', $options) && is_string($options['subaccount'])) {
+            $headers['X-MSYS-SUBACCOUNT'] = $options['subaccount'];
+        }
+
         foreach($suppressionLists as $suppressionList) {
             if (in_array($suppressionList, self::SUPPRESSION_LISTS)) {
                 $delete = [
                     'type' => $suppressionList,
                 ];
 
-                $response = $this->prepareHttpClient('/suppression-list/' . urlencode($emailAddress), $delete)
+                $response = $this->prepareHttpClient('/suppression-list/' . urlencode($emailAddress), $delete, $headers)
                     ->setMethod(HttpRequest::METHOD_DELETE)
                     ->send();
 
@@ -395,6 +420,12 @@ class SparkPostService extends AbstractMailService
 
     public function verifySendingDomain(string $domain, array $options = []): bool
     {
+        $headers = [];
+
+        if(array_key_exists('subaccount', $options) && is_string($options['subaccount'])) {
+            $headers['X-MSYS-SUBACCOUNT'] = $options['subaccount'];
+        }
+
         $dkimVerify = array_key_exists('dkim_verify', $options) && $options['dkim_verify'] === true;
         $post = [];
 
@@ -402,7 +433,7 @@ class SparkPostService extends AbstractMailService
             $post['dkim_verify'] = true;
         }
 
-        $response = $this->prepareHttpClient(sprintf('/sending-domains/%s/verify', urlencode($domain)), $post)
+        $response = $this->prepareHttpClient(sprintf('/sending-domains/%s/verify', urlencode($domain)), $post, $headers)
             ->send()
         ;
 
@@ -425,9 +456,15 @@ class SparkPostService extends AbstractMailService
         return true;
     }
 
-    public function removeSendingDomain(string $domain): void
+    public function removeSendingDomain(string $domain, array $options = []): void
     {
-        $response = $this->prepareHttpClient(sprintf('/sending-domains/%s', urlencode($domain)))
+        $headers = [];
+
+        if(array_key_exists('subaccount', $options) && is_string($options['subaccount'])) {
+            $headers['X-MSYS-SUBACCOUNT'] = $options['subaccount'];
+        }
+
+        $response = $this->prepareHttpClient(sprintf('/sending-domains/%s', urlencode($domain)), [], $headers)
             ->setMethod(HttpRequest::METHOD_DELETE)
             ->send()
         ;
@@ -438,18 +475,21 @@ class SparkPostService extends AbstractMailService
 
     /**
      * @param string $uri
-     * @param array  $parameters
+     * @param array $parameters API-call parameters, given associative array. Will be converted to JSON in the request.
+     * @param array $headers Optional extra headers. This function will always add/overwrite Authorization
+     *                       and Content-Type headers regardless of what was given in this parameter.
      * @return HttpClient
      */
-    private function prepareHttpClient(string $uri, array $parameters = []): HttpClient
+    private function prepareHttpClient(string $uri, array $parameters = [], array $headers = []): HttpClient
     {
         $parameters = json_encode($parameters);
+        $allHeaders = $headers;
+        $allHeaders['Authorization'] = $this->apiKey;
+        $allHeaders['Content-Type'] = 'application/json';
+
         return $this->getClient()
             ->resetParameters()
-            ->setHeaders([
-                'Authorization' => $this->apiKey,
-                'Content-Type' => 'application/json',
-            ])
+            ->setHeaders($allHeaders)
             ->setMethod(HttpRequest::METHOD_POST)
             ->setUri(self::API_ENDPOINT . $uri)
             ->setRawBody($parameters)
@@ -510,15 +550,21 @@ class SparkPostService extends AbstractMailService
         throw new RuntimeException('SparkPost server error, please try again');
     }
 
-    public function previewTemplate(string $templateId, array $substitutionVariables = []): array
+    public function previewTemplate(string $templateId, array $substitutionVariables = [], array $options = []): array
     {
+        $headers = [];
+
+        if(array_key_exists('subaccount', $options) && is_string($options['subaccount'])) {
+            $headers['X-MSYS-SUBACCOUNT'] = $options['subaccount'];
+        }
+
         // Request: POST/api/v1/templates/{id}/preview{?draft} ; with POST body given as JSON: { "substitution_data": { "key1": "value1", "key2": "value2" } }
         // Example: POST /api/v1/templates/11714265276872/preview?draft=true
         $post = [
             'substitution_data' => $substitutionVariables,
         ];
 
-        $response = $this->prepareHttpClient(sprintf('/templates/%s/preview', urlencode($templateId)), $post)
+        $response = $this->prepareHttpClient(sprintf('/templates/%s/preview', urlencode($templateId)), $post, $headers)
             ->send()
         ;
 

--- a/tests/SlmMailTest/Service/SparkPostServiceTest.php
+++ b/tests/SlmMailTest/Service/SparkPostServiceTest.php
@@ -65,8 +65,12 @@ class SparkPostServiceTest extends TestCase
         if(count($expectedRequestHeaders) > 0) {
             $httpClientMock->expects($this->atLeastOnce())
                 ->method('setHeaders')
-                ->with(self::callback(fn ($actualHeaders) =>
-                    $this->areMandatoryHeadersPresent($expectedRequestHeaders, ($actualHeaders instanceof Headers ? $actualHeaders->toArray() : $actualHeaders))));
+                ->with(self::callback(function ($actualHeaders) use ($expectedRequestHeaders) {
+                    return $this->areMandatoryHeadersPresent(
+                        $expectedRequestHeaders,
+                        ($actualHeaders instanceof Headers ? $actualHeaders->toArray() : $actualHeaders)
+                    );
+                }));
         }
 
         $sparkPostServiceMock = new SparkPostService('MyApiKey');


### PR DESCRIPTION
The public methods of the SparkPostService now support the option 'subaccount' for passing a SparkPost subaccount ID to execute the request on behalf of the given subaccount, when specified.