### PR TITLE
Implement laminas TransportInterface via MailServiceInterface

### DIFF
--- a/src/Service/MailServiceInterface.php
+++ b/src/Service/MailServiceInterface.php
@@ -41,15 +41,8 @@
 
 namespace SlmMail\Service;
 
-use Laminas\Mail\Message;
+use Laminas\Mail\Transport\TransportInterface;
 
-interface MailServiceInterface
+interface MailServiceInterface extends TransportInterface
 {
-    /**
-     * Send a message
-     *
-     * @param  Message $message
-     * @return mixed
-     */
-    public function send(Message $message);
 }


### PR DESCRIPTION
Hi

I am investigating using this package in a project that will use AWS SES in production, but I want to use Mailhog mock SMTP server for local testing. 

This project explicitly says it does _not_ support SMTP, which is fine cause I can just use the SMTP implementation that ships with Laminas Mail for dev then.
But any factory I write to return the transport based on the environment will not be able to return a single interface, as it appears you re-implemented the `Laminas\Mail\Transport\TransportInterface` with your `SlmMail\ServiceMailServiceInterface`. I would need to create my own application interface that is just a copy of `TransportInterface` and `ServiceMailServiceInterface`, which doesn't seem ideal.

So would you be open to this change? If so, is there a reason not to include an SMTP implementation in this package that simply extends the [existing Laminas Smtp](https://github.com/laminas/laminas-mail/blob/2.17.x/src/Transport/Smtp.php) class? I can add that to this PR if you are comfortable with that?