### PR TITLE
Move to Psr containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "7.2"
-                    - "7.3"
                     - "7.4"
                     - "8.0"
+                    - "8.1"
+                    - "8.2"
                 dependencies:
                     - "highest"
                     - "lowest"

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "doctrine/instantiator": "^1.3",
         "squizlabs/php_codesniffer": "^3.5",
         "phpunit/phpunit": "^9.4.2",
-        "aws/aws-sdk-php": "^3.184"
+        "aws/aws-sdk-php": "^3.208.4"
     },
     "suggest": {
         "aws/aws-sdk-php": "If you need to use Amazon SES"

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "laminas/laminas-config": "^3.3",
         "doctrine/instantiator": "^1.3",
         "squizlabs/php_codesniffer": "^3.5",
-        "phpunit/phpunit": "^8.5.8 || ^9.4.2",
+        "phpunit/phpunit": "^9.4.2",
         "aws/aws-sdk-php": "^3.184"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,10 @@
         "laminas/laminas-mail": "^2.9",
         "laminas/laminas-http": "^2.8",
         "laminas/laminas-mime": "^2.7",
-        "laminas/laminas-servicemanager": "^3.3"
+        "laminas/laminas-servicemanager": "^3.11"
     },
     "require-dev": {
-        "container-interop/container-interop": "^1.1",
+        "psr/container": "^1.0 || ^2.0",
         "guzzlehttp/guzzle": "^7.4",
         "laminas/laminas-modulemanager": "^2.8",
         "laminas/laminas-mvc": "^3.1",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0",
         "laminas/laminas-mail": "^2.9",
         "laminas/laminas-http": "^2.8",
         "laminas/laminas-mime": "^2.7",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "laminas/laminas-config": "^3.3",
         "doctrine/instantiator": "^1.3",
         "squizlabs/php_codesniffer": "^3.5",
-        "phpunit/phpunit": "^9.4.2",
+        "phpunit/phpunit": "^9.6.5",
         "aws/aws-sdk-php": "^3.208.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         }
     },
     "extra": {
-        "zf": {
+        "laminas": {
             "component": "SlmMail",
             "config-provider": "SlmMail\\ConfigProvider"
         }

--- a/src/Factory/AwsSdkFactory.php
+++ b/src/Factory/AwsSdkFactory.php
@@ -5,7 +5,7 @@ namespace SlmMail\Factory;
 
 
 use Aws\Sdk;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Factory\Exception\RuntimeException;
 

--- a/src/Factory/ElasticEmailServiceFactory.php
+++ b/src/Factory/ElasticEmailServiceFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Factory\Exception\RuntimeException;
 use SlmMail\Service\ElasticEmailService;

--- a/src/Factory/ElasticEmailTransportFactory.php
+++ b/src/Factory/ElasticEmailTransportFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Mail\Transport\HttpTransport;
 use SlmMail\Service\ElasticEmailService;

--- a/src/Factory/HttpClientFactory.php
+++ b/src/Factory/HttpClientFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\Http\Client as HttpClient;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 

--- a/src/Factory/MailgunServiceFactory.php
+++ b/src/Factory/MailgunServiceFactory.php
@@ -41,8 +41,8 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface;
 use SlmMail\Factory\Exception\RuntimeException;
 use SlmMail\Service\MailgunService;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;

--- a/src/Factory/MailgunTransportFactory.php
+++ b/src/Factory/MailgunTransportFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Mail\Transport\HttpTransport;
 use SlmMail\Service\MailgunService;

--- a/src/Factory/MandrillServiceFactory.php
+++ b/src/Factory/MandrillServiceFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Factory\Exception\RuntimeException;
 use SlmMail\Service\MandrillService;

--- a/src/Factory/MandrillTransportFactory.php
+++ b/src/Factory/MandrillTransportFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Mail\Transport\HttpTransport;
 use SlmMail\Service\MandrillService;

--- a/src/Factory/PostageServiceFactory.php
+++ b/src/Factory/PostageServiceFactory.php
@@ -41,8 +41,8 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface;
 use SlmMail\Factory\Exception\RuntimeException;
 use SlmMail\Service\PostageService;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;

--- a/src/Factory/PostageTransportFactory.php
+++ b/src/Factory/PostageTransportFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Mail\Transport\HttpTransport;
 use SlmMail\Service\PostageService;

--- a/src/Factory/PostmarkServiceFactory.php
+++ b/src/Factory/PostmarkServiceFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Factory\Exception\RuntimeException;
 use SlmMail\Service\PostmarkService;

--- a/src/Factory/PostmarkTransportFactory.php
+++ b/src/Factory/PostmarkTransportFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Mail\Transport\HttpTransport;
 use SlmMail\Service\PostmarkService;

--- a/src/Factory/SendGridServiceFactory.php
+++ b/src/Factory/SendGridServiceFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Factory\Exception\RuntimeException;
 use SlmMail\Service\SendGridService;

--- a/src/Factory/SendGridTransportFactory.php
+++ b/src/Factory/SendGridTransportFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Mail\Transport\HttpTransport;
 use SlmMail\Service\SendGridService;

--- a/src/Factory/SesServiceFactory.php
+++ b/src/Factory/SesServiceFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Service\SesService;
 

--- a/src/Factory/SesTransportFactory.php
+++ b/src/Factory/SesTransportFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Mail\Transport\HttpTransport;
 use SlmMail\Service\SesService;

--- a/src/Factory/SparkPostServiceFactory.php
+++ b/src/Factory/SparkPostServiceFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Factory\Exception\RuntimeException;
 use SlmMail\Service\SparkPostService;

--- a/src/Factory/SparkPostTransportFactory.php
+++ b/src/Factory/SparkPostTransportFactory.php
@@ -41,7 +41,7 @@
 
 namespace SlmMail\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use SlmMail\Mail\Transport\HttpTransport;
 use SlmMail\Service\SparkPostService;

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./Bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./Bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false">
   <coverage includeUncoveredFiles="true">
     <include>
       <directory suffix=".php">./src</directory>


### PR DESCRIPTION
Move to Psr containers (deprecating Interop\Container\ContainerInterface) and bump the minimum version of `laminas-servicemanager` to [3.11](https://github.com/laminas/laminas-servicemanager/releases/tag/3.11.0), which deprecate Interop\Container\ContainerInterface.

Small fix in composer.json (zf -> laminas).