### PR TITLE
Set encoding type to json for Postmark send()s

### DIFF
--- a/src/Service/PostmarkService.php
+++ b/src/Service/PostmarkService.php
@@ -188,6 +188,7 @@ class PostmarkService extends AbstractMailService
 
         $response = $this->prepareHttpClient('/email')
                          ->setMethod(HttpRequest::METHOD_POST)
+                         ->setEncType('application/json')
                          ->setRawBody(json_encode($this->filterParameters($parameters)))
                          ->send();
 


### PR DESCRIPTION
Postmark now requires requests be sent as `application/json`

https://postmarkapp.com/updates/changes-to-email-api-validation-action-may-be-required

Fixes #155 