### PR TITLE
Added ability to extract text and html from multipart messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,69 @@ $message->setBody($body);
 
 > For accessibility purposes, you should *always* provide both a text and HTML version of your mails.
 
+### `multipart/alternative` emails with attachments
+
+The correct way to compose an email message that contains text, html _and_ attachments is to create a 
+`multipart/alternative` part containing the text and html parts, followed by one or more parts for the attachments.
+
+If you have an existing application using `laminas/laminas-mail`, the developers probably followed the 
+[Laminas Documentation](https://docs.laminas.dev/laminas-mail/message/attachments/#multipartalternative-emails-with-attachments),
+in which case the `multipart/alternative` content part may not have any boundary defined. This library **needs** that 
+boundary to parse out the text and html.
+
+For existing applications, check that it is set when your code creates the content MIME part:
+
+```php
+$content = new MimeMessage();
+$content->setParts([$text, $html]);
+$contentPart = (new MimePart($content->generateMessage()))
+   ->setBoundary($content->getMime()->boundary()); // <-- THIS IS REQUIRED!
+```
+
+If you are starting from scratch, here's the example from the Laminas documentation modified to work correctly:
+
+```php
+use Laminas\Mail\Message;
+use Laminas\Mime\Message as MimeMessage;
+use Laminas\Mime\Mime;
+use Laminas\Mime\Part as MimePart;
+
+$body = new MimeMessage();
+
+$text           = new MimePart($textContent);
+$text->type     = Mime::TYPE_TEXT;
+$text->charset  = 'utf-8';
+$text->encoding = Mime::ENCODING_QUOTEDPRINTABLE;
+
+$html           = new MimePart($htmlMarkup);
+$html->type     = Mime::TYPE_HTML;
+$html->charset  = 'utf-8';
+$html->encoding = Mime::ENCODING_QUOTEDPRINTABLE;
+
+$content = new MimeMessage();
+// This order is important for email clients to properly display the correct version of the content
+$content->setParts([$text, $html]);
+
+$contentPart = (new MimePart($content->generateMessage()))
+   ->setType(Mime::MULTIPART_ALTERNATIVE)
+   ->setBoundary($content->getMime()->boundary());;
+
+$image              = new MimePart(fopen($pathToImage, 'r'));
+$image->type        = 'image/jpeg';
+$image->filename    = 'image-file-name.jpg';
+$image->disposition = Mime::DISPOSITION_ATTACHMENT;
+$image->encoding    = Mime::ENCODING_BASE64;
+
+$body = new MimeMessage();
+$body->setParts([$contentPart, $image]);
+
+$message = new Message();
+$message->setBody($body);
+
+$contentTypeHeader = $message->getHeaders()->get('Content-Type');
+$contentTypeHeader->setType(Mime::MULTIPART_RELATED);
+```
+
 ### How to configure HttpClient with http_options and http_adapter
 
 By default the adapter is Laminas\Http\Client\Adapter\Socket but you can override it with other adapter like this in your slm_mail.*.local.php

--- a/README.md
+++ b/README.md
@@ -106,65 +106,9 @@ $message->setBody($body);
 ### `multipart/alternative` emails with attachments
 
 The correct way to compose an email message that contains text, html _and_ attachments is to create a 
-`multipart/alternative` part containing the text and html parts, followed by one or more parts for the attachments.
-
-If you have an existing application using `laminas/laminas-mail`, the developers probably followed the 
-[Laminas Documentation](https://docs.laminas.dev/laminas-mail/message/attachments/#multipartalternative-emails-with-attachments),
-in which case the `multipart/alternative` content part may not have any boundary defined. This library **needs** that 
-boundary to parse out the text and html.
-
-For existing applications, check that it is set when your code creates the content MIME part:
-
-```php
-$content = new MimeMessage();
-$content->setParts([$text, $html]);
-$contentPart = (new MimePart($content->generateMessage()))
-   ->setBoundary($content->getMime()->boundary()); // <-- THIS IS REQUIRED!
-```
-
-If you are starting from scratch, here's the example from the Laminas documentation modified to work correctly:
-
-```php
-use Laminas\Mail\Message;
-use Laminas\Mime\Message as MimeMessage;
-use Laminas\Mime\Mime;
-use Laminas\Mime\Part as MimePart;
-
-$body = new MimeMessage();
-
-$text           = new MimePart($textContent);
-$text->type     = Mime::TYPE_TEXT;
-$text->charset  = 'utf-8';
-$text->encoding = Mime::ENCODING_QUOTEDPRINTABLE;
-
-$html           = new MimePart($htmlMarkup);
-$html->type     = Mime::TYPE_HTML;
-$html->charset  = 'utf-8';
-$html->encoding = Mime::ENCODING_QUOTEDPRINTABLE;
-
-$content = new MimeMessage();
-// This order is important for email clients to properly display the correct version of the content
-$content->setParts([$text, $html]);
-
-$contentPart = (new MimePart($content->generateMessage()))
-   ->setType(Mime::MULTIPART_ALTERNATIVE)
-   ->setBoundary($content->getMime()->boundary());;
-
-$image              = new MimePart(fopen($pathToImage, 'r'));
-$image->type        = 'image/jpeg';
-$image->filename    = 'image-file-name.jpg';
-$image->disposition = Mime::DISPOSITION_ATTACHMENT;
-$image->encoding    = Mime::ENCODING_BASE64;
-
-$body = new MimeMessage();
-$body->setParts([$contentPart, $image]);
-
-$message = new Message();
-$message->setBody($body);
-
-$contentTypeHeader = $message->getHeaders()->get('Content-Type');
-$contentTypeHeader->setType(Mime::MULTIPART_RELATED);
-```
+`multipart/alternative` part containing the text and html parts, followed by one or more parts for the attachments. See
+the [Laminas Documentation](https://docs.laminas.dev/laminas-mail/message/attachments/#multipartalternative-emails-with-attachments)
+for a full example.
 
 ### How to configure HttpClient with http_options and http_adapter
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0",
         "laminas/laminas-mail": "^2.9",
         "laminas/laminas-http": "^2.8",
-        "laminas/laminas-mime": "^2.7",
+        "laminas/laminas-mime": "^2.8",
         "laminas/laminas-servicemanager": "^3.11"
     },
     "require-dev": {

--- a/tests/SlmMailTest/Service/AbstractMailServiceTest.php
+++ b/tests/SlmMailTest/Service/AbstractMailServiceTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlmMailTest\Service;
+
+use Laminas\Mail\Message;
+use Laminas\Mime\Message as MimeMessage;
+use Laminas\Mime\Mime;
+use Laminas\Mime\Part;
+use SlmMail\Service\AbstractMailService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \SlmMail\Service\AbstractMailService
+ */
+final class AbstractMailServiceTest extends TestCase
+{
+    private AbstractMailService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new class () extends AbstractMailService {
+            public ?string $text = null;
+            public ?string $html = null;
+            public array $attachments = [];
+
+            public function send(Message $message)
+            {
+                $this->text = $this->extractText($message);
+                $this->html = $this->extractHtml($message);
+                $this->attachments = $this->extractAttachments($message);
+            }
+        };
+    }
+
+    public function testExtractTextFromStringBodyReturnsString(): void
+    {
+        $expected = 'Foo';
+        $message = new Message();
+        $message->setBody($expected);
+
+        $this->service->send($message);
+        self::assertSame($expected, $this->service->text);
+    }
+
+    public function testExtractTextFromEmptyBodyReturnsNull(): void
+    {
+        $message = new Message();
+
+        $this->service->send($message);
+        self::assertNull($this->service->text);
+    }
+
+    public function testExtractTextFromTwoPartMessageReturnsString(): void
+    {
+        $expected = 'Foo';
+        $message = new Message();
+        $body = new MimeMessage();
+        $body->addPart(new Part(''));
+        $body->addPart(
+            (new Part($expected))
+                ->setType(Mime::TYPE_TEXT)
+        );
+        $message->setBody($body);
+
+        $this->service->send($message);
+        self::assertSame($expected, $this->service->text);
+    }
+
+    public function testExtractTextFromTextAttachmentReturnsNull(): void
+    {
+        $message = new Message();
+        $body = new MimeMessage();
+        $body->addPart(
+            (new Part('Foo'))
+                ->setType(Mime::TYPE_TEXT)
+                ->setDisposition(Mime::DISPOSITION_ATTACHMENT)
+        );
+        $message->setBody($body);
+
+        $this->service->send($message);
+        self::assertNull($this->service->text);
+    }
+
+    public function testExtractTextFromMultipartMessageReturnsString(): void
+    {
+        $expected = 'Foo';
+        $message = new Message();
+        $body = new MimeMessage();
+        $contentPart = new MimeMessage();
+        $contentPart->addPart(new Part());
+        $contentPart->addPart(
+            (new Part($expected))
+                ->setType(Mime::TYPE_TEXT)
+        );
+        $body->addPart(
+            (new Part($contentPart->generateMessage()))
+                ->setType(Mime::MULTIPART_ALTERNATIVE)
+                ->setBoundary($contentPart->getMime()->boundary())
+        );
+        $message->setBody($body);
+
+        $this->service->send($message);
+        self::assertSame($expected, trim($this->service->text));
+    }
+
+    public function testExtractHtmlFromStringBodyReturnsNull(): void
+    {
+        $message = new Message();
+        $message->setBody('Foo');
+
+        $this->service->send($message);
+        self::assertNull($this->service->html);
+    }
+
+    public function testExtractHtmlFromEmptyBodyReturnsNull(): void
+    {
+        $message = new Message();
+
+        $this->service->send($message);
+        self::assertNull($this->service->html);
+    }
+
+    public function testExtractHtmlFromTwoPartMessageReturnsString(): void
+    {
+        $expected = 'Foo';
+        $message = new Message();
+        $body = new MimeMessage();
+        $body->addPart(new Part(''));
+        $body->addPart(
+            (new Part($expected))
+                ->setType(Mime::TYPE_HTML)
+        );
+        $message->setBody($body);
+
+        $this->service->send($message);
+        self::assertSame($expected, $this->service->html);
+    }
+
+    public function testExtractHtmlFromHtmlAttachmentReturnsNull(): void
+    {
+        $message = new Message();
+        $body = new MimeMessage();
+        $body->addPart(
+            (new Part('Foo'))
+                ->setType(Mime::TYPE_HTML)
+                ->setDisposition(Mime::DISPOSITION_ATTACHMENT)
+        );
+        $message->setBody($body);
+
+        $this->service->send($message);
+        self::assertNull($this->service->html);
+    }
+
+    public function testExtractHtmlFromMultipartMessageReturnsString(): void
+    {
+        $expected = 'Foo';
+        $message = new Message();
+        $body = new MimeMessage();
+        $contentPart = new MimeMessage();
+        $contentPart->addPart(new Part());
+        $contentPart->addPart(
+            (new Part($expected))
+                ->setType(Mime::TYPE_HTML)
+        );
+        $body->addPart(
+            (new Part($contentPart->generateMessage()))
+                ->setType(Mime::MULTIPART_ALTERNATIVE)
+                ->setBoundary($contentPart->getMime()->boundary())
+        );
+        $message->setBody($body);
+
+        $this->service->send($message);
+        self::assertSame($expected, trim($this->service->html));
+    }
+}


### PR DESCRIPTION
I'm moving an application that uses vanilla `laminas-mail` to this library. It composes email messages with text, html and attachment parts pretty-much exactly as described in https://docs.laminas.dev/laminas-mail/message/attachments/#multipartalternative-emails-with-attachments, with a `multipart/alternative` part containing the text and html, followed by one or more parts for the attachments.

Currently this library doesn't look inside the `multipart/alternative` part, so never finds the text and html. This PR fixes that.