### PR TITLE
Add an option to use only API key - header authentication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "laminas/laminas-servicemanager": "^3.11"
     },
     "require-dev": {
+        "ext-json": "*",
         "psr/container": "^1.0 || ^2.0",
         "guzzlehttp/guzzle": "^7.4",
         "laminas/laminas-modulemanager": "^2.8",

--- a/config/slm_mail.send_grid.local.php.dist
+++ b/config/slm_mail.send_grid.local.php.dist
@@ -5,6 +5,7 @@ return array(
         'send_grid' => array(
             /**
              * Set your Send Grid username
+             * If empty string then header authentication will be used
              */
             // 'username' => '',
 

--- a/config/slm_mail.send_grid.local.php.dist
+++ b/config/slm_mail.send_grid.local.php.dist
@@ -4,12 +4,6 @@ return array(
     'slm_mail' => array(
         'send_grid' => array(
             /**
-             * Set your Send Grid username
-             * If empty string then header authentication will be used
-             */
-            // 'username' => '',
-
-            /**
              * Set your Send Grid API key
              */
             // 'key' => '',

--- a/src/Factory/SendGridServiceFactory.php
+++ b/src/Factory/SendGridServiceFactory.php
@@ -59,7 +59,7 @@ class SendGridServiceFactory implements FactoryInterface
         }
 
         $config  = $config['slm_mail']['send_grid'];
-        $service = new SendGridService($config['username'], $config['key']);
+        $service = new SendGridService($config['key']);
 
         $client  = $container->get('SlmMail\Http\Client');
         $service->setClient($client);

--- a/src/Service/SendGridService.php
+++ b/src/Service/SendGridService.php
@@ -55,13 +55,6 @@ class SendGridService extends AbstractMailService
     protected const API_ENDPOINT = 'https://sendgrid.com/api';
 
     /**
-     * SendGrid username
-     *
-     * @var string
-     */
-    protected $username;
-
-    /**
      * SendGrid API key
      *
      * @var string
@@ -70,14 +63,10 @@ class SendGridService extends AbstractMailService
 
 
     /**
-     * If $username is an empty string header authentication will be used
-     *
-     * @param string $username
      * @param string $apiKey
      */
-    public function __construct(string $username, string $apiKey)
+    public function __construct(string $apiKey)
     {
-        $this->username = $username;
         $this->apiKey   = $apiKey;
     }
 
@@ -346,24 +335,15 @@ class SendGridService extends AbstractMailService
      */
     private function prepareHttpClient(string $uri, array $parameters = []): HttpClient
     {
-        if ($this->username) {
-            $parameters = array_merge(
-                ['api_user' => $this->username, 'api_key' => $this->apiKey],
-                $parameters
-            );
-        }
-
         $client = $this->getClient()
             ->resetParameters()
             ->setMethod(HttpRequest::METHOD_GET)
             ->setUri(self::API_ENDPOINT . $uri)
             ->setParameterGet($this->filterParameters($parameters));
 
-        if (! $this->username) {
-            $client->setHeaders([
-                'Authorization' => sprintf('Bearer %s', $this->apiKey),
-            ]);
-        }
+        $client->setHeaders([
+            'Authorization' => sprintf('Bearer %s', $this->apiKey),
+        ]);
 
         return $client;
     }


### PR DESCRIPTION
This PR keep backward compatibility but also allows using only the API key to authenticate the request.