### PR TITLE
Improve SparkPost exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Here are the currently supported services:
 * [Mailgun](http://www.mailgun.com) (complete)
 * [Postmark](https://postmarkapp.com) (complete)
 * [Postage](http://postageapp.com) (complete)
-* [Send Grid](http://sendgrid.com) (nearly complete)
-* [Spark Post](http://sparkpost.com) (nearly complete)
+* [SendGrid](http://sendgrid.com) (nearly complete)
+* [SparkPost](http://sparkpost.com) (nearly complete)
 * [Amazon SES](http://aws.amazon.com/ses) (nearly complete, attachments are missing)
 * [Mandrill](http://mandrill.com) (complete, but please don't use this party, as Mailchimp / Mandrill do not actively maintain this service)
 

--- a/src/Service/SparkPostService.php
+++ b/src/Service/SparkPostService.php
@@ -524,32 +524,27 @@ class SparkPostService extends AbstractMailService
             return $result;
         }
 
-        // There is a 4xx error
-        if ($response->isClientError()) {
-            if (isset($result['errors']) && is_array($result['errors'])) {
-                $message = implode(', ', array_map(
-                    function ($error) {
-                        return $error['message'];
-                    },
-                    $result['errors']
-                ));
-            } elseif (isset($result['error'])) {
-                $message = $result['error'];
-            } else {
-                $message = 'Unknown error';
-            }
-
-            throw new RuntimeException(
-                sprintf(
-                    'An error occurred on SparkPost (http code %s), messages: %s',
-                    $response->getStatusCode(),
-                    $message
-                )
-            );
+        if (isset($result['errors']) && is_array($result['errors'])) {
+            $message = implode(', ', array_map(
+                function ($error) {
+                    return $error['message'];
+                },
+                $result['errors']
+            ));
+        } elseif (isset($result['error'])) {
+            $message = $result['error'];
+        } else {
+            $message = 'Unknown error';
         }
 
-        // There is a 5xx error
-        throw new RuntimeException('SparkPost server error, please try again');
+        throw new RuntimeException(
+            sprintf(
+                'An error occurred on SparkPost (http code %s), messages: %s',
+                $response->getStatusCode(),
+                $message
+            ),
+            $response->getStatusCode()
+        );
     }
 
     public function previewTemplate(


### PR DESCRIPTION
When SparkPost melts and returns anything but a 2xx or 4xx status code, the library assumes it's a 5xx error without including any distinguishable error information. This PR changes it so the response status code is always set on the exception and the error message is included when available.

This is done to aid in debugging. If we _wanted_ users to distinguish different error types, we should be mapping the responses to different codes or exceptions altogether.